### PR TITLE
feat: add basic postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+BITNAMI_POSTGRES_RELEASE=13.2.24
+
+.PHONY: gen-postgresql
+gen-postgresql:
+	docker run -ti --rm \
+			--volume $${PWD}:/opt/manifests \
+			--env BITNAMI_POSTGRES_RELEASE=${BITNAMI_POSTGRESQL_RELEASE} \
+			--workdir=/opt/manifests \
+			--entrypoint=/bin/sh \
+			alpine/helm ./gen-yaml/gen.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # energy-postgres-base
-Base manifest for energy postgres instances.
+
+> [!WARNING]
+> This is still a wip so it not ready for general use.
+> - TODO need to fix an issue upstream where the backup directory is not set. [link](https://github.com/eeshugerman/postgres-backup-s3/pull/43)
+> - TODO test the restore process.
+> - TODO create a nice manifest for doing a restore.
+
+## Source
+The postgres manifest is built on the base of [Bitnami Postgresql Helm Chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
+
+The backup cronjob is provided by using an [image](https://github.com/eeshugerman/postgres-backup-s3) for backing up to an S3 bucket.
+
+## Usage
+It is expected that these manifests would be used as a Kustomize base with patches applied to suit your particular use case and requirements. An example of a possible setup is provided in the [examples](./examples) folder

--- a/examples/backup-pvc.yaml
+++ b/examples/backup-pvc.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-backup-pvc
+spec:
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/backup.yaml
+++ b/examples/backup.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-backup
+spec:
+  schedule: "@daily"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            injector.tumblr.com/request: vault-init-container-aws
+        spec:
+          serviceAccountName: <service-account-with-vault-access>
+          containers:
+            - name: postgres-backup
+              image: eeshugerman/postgres-backup-s3:16
+              env:
+                - name: S3_BUCKET
+                  value: "<s3-bucket-name>"
+                - name: S3_PREFIX
+                  value: "<s3-folder-name>"
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: example-postgres-secrets
+                      key: user
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: example-postgres-secrets
+                      key: password
+                - name: POSTGRES_DATABASE
+                  value: "example"
+          volumes:
+            - name: postgres-backup-pvc
+              persistentVolumeClaim:
+                claimName: example-backup-pvc

--- a/examples/kustomization.yaml
+++ b/examples/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: example-a-
+namespace: "<your-namespace>"
+resources:
+  - http://github.com/utilitywarehouse/shared-kustomize-bases//postgresql/manifests/postgres-with-backup?ref=<update-ref-here>
+secretGenerator:
+  - name: postgresql
+    envs:
+      - secrets/postgres.properties
+    options:
+          disableNameSuffixHash: true
+patches:
+  - path: backup.yaml
+  - path: backup-pvc.yaml
+  - path: postgres.yaml

--- a/examples/postgres.yaml
+++ b/examples/postgres.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql
+spec:
+  template:
+    spec:
+      serviceAccountName: <service-account-with-vault-access>
+      containers:
+        - name: postgresql
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: example-postgresql
+                  key: password
+            - name: POSTGRES_DATABASE
+              value: "example"
+            - name: POSTGRES_USER
+              value: "example-user"
+        - name: metrics
+          env:
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: example-postgresql
+                  key: password
+            - name: DATA_SOURCE_USER
+              value: "postgres"
+            - name: DATA_SOURCE_URI
+              value: 127.0.0.1:5432/$(POSTGRES_DATABASE)?sslmode=disable
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi

--- a/examples/secrets/postgres.properties
+++ b/examples/secrets/postgres.properties
@@ -1,0 +1,2 @@
+password=adminpassword
+user-password=userpassword

--- a/gen-yaml/gen.sh
+++ b/gen-yaml/gen.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit -o pipefail -o nounset
+
+mkdir -p manifests/base/upstream
+rm -f manifests/base/upstream/*
+
+# Fetch from helm repo: https://github.com/bitnami/charts/tree/main/bitnami/postgresql
+helm repo add bitnami https://charts.bitnami.com/bitnami
+
+helm template "postgresql" bitnami/postgresql --version "${BITNAMI_POSTGRES_RELEASE}" \
+  --set fullnameOverride="postgresql" \
+  --set nameOverride="postgresql" \
+  --set commonAnnotations."app\.uw\.systems\/description"="" \
+  --set commonAnnotations."app\.uw\.systems\/tier"="" \
+  --set commonAnnotations."app\.uw\.systems\/repos"="https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/postgresql" \
+  --set auth.existingSecret="postgresql" \
+  --set auth.secretKeys.adminPasswordKey="password" \
+  --set auth.secretKeys.userPasswordKey="user-password" \
+  --set global.postgresql.auth.database="database" \
+  --set global.postgresql.auth.username="testuser" \
+  --set primary.resources.requests.cpu="0" \
+  --set primary.resources.limits.cpu="1000m" \
+  --set primary.resources.requests.memory="0" \
+  --set primary.resources.limits.memory="1Gi" \
+  --set metrics.enabled="true" \
+  --set backup.enabled="false" > manifests/base/upstream/postgres.yaml
+
+cp gen-yaml/kustomization.yaml manifests/base/upstream/kustomization.yaml

--- a/gen-yaml/kustomization.yaml
+++ b/gen-yaml/kustomization.yaml
@@ -1,0 +1,58 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - postgres.yaml
+patches:
+  # Remove unnecessary `app.kubernetes.io/managed-by: Helm` annotation
+  - patch: |-
+      - op: remove
+        path: /metadata/labels/app.kubernetes.io~1managed-by
+    target:
+      group: apps
+      version: v1
+      kind: Service
+  - patch: |-
+      - op: remove
+        path: /spec/template/metadata/labels/app.kubernetes.io~1managed-by
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+  # remove these empty affinity nodes, as in Kustomize 5.0.x kustomize generates them as strings with value "null" instead of just null, and they can not be applied.
+  # added this issue in kustomize: https://github.com/kubernetes-sigs/kustomize/issues/5171
+  - patch: |-
+      - op: remove
+        path: /spec/template/spec/affinity/podAffinity
+      - op: remove
+        path: /spec/template/spec/affinity/nodeAffinity
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+  # replace commands with hardcoded values with more flexible commands
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/livenessProbe/exec/command
+        value:
+          - /bin/sh
+          - -c
+          - |
+            exec pg_isready -U "$(POSTGRES_USER)" -d "dbname=$(POSTGRES_DATABASE)" -h 127.0.0.1 -p 5432
+            [-f /opt/bitnami/postgresql/tmp/.initialized] || [-f /bitnami/postgresql/.initialized]
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe/exec/command
+        value:
+          - /bin/sh
+          - -c
+          - |
+            exec pg_isready -U "$(POSTGRES_USER)" -d "dbname=$(POSTGRES_DATABASE)" -h 127.0.0.1 -p 5432
+            [-f /opt/bitnami/postgresql/tmp/.initialized] || [-f /bitnami/postgresql/.initialized]
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet

--- a/manifests/base/backup/backup-pvc.yaml
+++ b/manifests/base/backup/backup-pvc.yaml
@@ -1,0 +1,11 @@
+# PVC for backup volume
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-backup-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/manifests/base/backup/backup.yaml
+++ b/manifests/base/backup/backup.yaml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-backup
+  labels:
+    app: postgres-backup
+spec:
+  schedule: "@daily"
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            injector.tumblr.com/request: vault-init-container-aws
+        spec:
+          imagePullSecrets:
+            - name: dockerhub-key
+          serviceAccountName: service-account-name
+          containers:
+            - name: postgres-backup
+              image: eeshugerman/postgres-backup-s3:15
+              imagePullPolicy: "IfNotPresent"
+              volumeMounts:
+                - mountPath: /backups
+                  name: postgres-backup-pvc
+              # after the backup is complete cleanup the backup files
+              lifecycle:
+                preStop:
+                  exec:
+                    command: ["/bin/sh", "-c", "rm /backups/*"]
+              env:
+                - name: S3_REGION
+                  value: "eu-west"
+                - name: S3_BUCKET
+                  value: "s3-bucket-name"
+                - name: S3_PREFIX
+                  value: "backups"
+                - name: POSTGRES_HOST
+                  value: "postgres"
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql
+                      key: user
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql
+                      key: admin-password
+                - name: POSTGRES_DATABASE
+                  value: "database"
+                - name: POSTGRES_PORT
+                  value: "5432"
+                - name: PGDUMP_EXTRA_OPTS
+                  value: "-f /backups/file"
+          restartPolicy: OnFailure
+          volumes:
+            - name: postgres-backup-pvc
+              persistentVolumeClaim:
+                claimName: postgres-backup-pvc

--- a/manifests/base/backup/kustomization.yaml
+++ b/manifests/base/backup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - backup.yaml
+  - backup-pvc.yaml

--- a/manifests/base/upstream/kustomization.yaml
+++ b/manifests/base/upstream/kustomization.yaml
@@ -1,0 +1,58 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - postgres.yaml
+patches:
+  # Remove unnecessary `app.kubernetes.io/managed-by: Helm` annotation
+  - patch: |-
+      - op: remove
+        path: /metadata/labels/app.kubernetes.io~1managed-by
+    target:
+      group: apps
+      version: v1
+      kind: Service
+  - patch: |-
+      - op: remove
+        path: /spec/template/metadata/labels/app.kubernetes.io~1managed-by
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+  # remove these empty affinity nodes, as in Kustomize 5.0.x kustomize generates them as strings with value "null" instead of just null, and they can not be applied.
+  # added this issue in kustomize: https://github.com/kubernetes-sigs/kustomize/issues/5171
+  - patch: |-
+      - op: remove
+        path: /spec/template/spec/affinity/podAffinity
+      - op: remove
+        path: /spec/template/spec/affinity/nodeAffinity
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+  # replace commands with hardcoded values with more flexible commands
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/livenessProbe/exec/command
+        value:
+          - /bin/sh
+          - -c
+          - |
+            exec pg_isready -U "$(POSTGRES_USER)" -d "dbname=$(POSTGRES_DATABASE)" -h 127.0.0.1 -p 5432
+            [-f /opt/bitnami/postgresql/tmp/.initialized] || [-f /bitnami/postgresql/.initialized]
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe/exec/command
+        value:
+          - /bin/sh
+          - -c
+          - |
+            exec pg_isready -U "$(POSTGRES_USER)" -d "dbname=$(POSTGRES_DATABASE)" -h 127.0.0.1 -p 5432
+            [-f /opt/bitnami/postgresql/tmp/.initialized] || [-f /bitnami/postgresql/.initialized]
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet

--- a/manifests/base/upstream/postgres.yaml
+++ b/manifests/base/upstream/postgres.yaml
@@ -1,0 +1,326 @@
+---
+# Source: postgresql/templates/primary/metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql-metrics
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: postgresql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 16.1.0
+    helm.sh/chart: postgresql-13.2.26
+    app.kubernetes.io/component: metrics
+  annotations:
+    app.uw.systems/description: ""
+    app.uw.systems/repos: https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/postgresql
+    app.uw.systems/tier: ""
+    prometheus.io/port: "9187"
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http-metrics
+      port: 9187
+      targetPort: http-metrics
+  selector:
+    app.kubernetes.io/instance: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary
+---
+# Source: postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql-hl
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: postgresql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 16.1.0
+    helm.sh/chart: postgresql-13.2.26
+    app.kubernetes.io/component: primary
+  annotations:
+    app.uw.systems/description: ""
+    app.uw.systems/repos: https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/postgresql
+    app.uw.systems/tier: ""
+    # Use this annotation in addition to the actual publishNotReadyAddresses
+    # field below because the annotation will stop being respected soon but the
+    # field is broken in some versions of Kubernetes:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary
+---
+# Source: postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: postgresql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 16.1.0
+    helm.sh/chart: postgresql-13.2.26
+    app.kubernetes.io/component: primary
+  annotations:
+    app.uw.systems/description: ""
+    app.uw.systems/repos: https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/postgresql
+    app.uw.systems/tier: ""
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary
+---
+# Source: postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: postgresql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 16.1.0
+    helm.sh/chart: postgresql-13.2.26
+    app.kubernetes.io/component: primary
+  annotations:
+    app.uw.systems/description: ""
+    app.uw.systems/repos: https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/postgresql
+    app.uw.systems/tier: ""
+spec:
+  replicas: 1
+  serviceName: postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: postgresql
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: postgresql
+      labels:
+        app.kubernetes.io/instance: postgresql
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/version: 16.1.0
+        helm.sh/chart: postgresql-13.2.26
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: default
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: postgresql
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnami/postgresql:16.1.0-debian-11-r17
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "testuser"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: user-password
+            - name: POSTGRES_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: password
+            - name: POSTGRES_DATABASE
+              value: "database"
+            # Replication
+            # Initdb
+            # Standby
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "testuser" -d "dbname=database" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "testuser" -d "dbname=database" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 0
+              memory: 0
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+        - name: metrics
+          image: docker.io/bitnami/postgres-exporter:0.15.0-debian-11-r4
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: DATA_SOURCE_URI
+              value: 127.0.0.1:5432/database?sslmode=disable
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: user-password
+            - name: DATA_SOURCE_USER
+              value: "testuser"
+          ports:
+            - name: http-metrics
+              containerPort: 9187
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /
+              port: http-metrics
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /
+              port: http-metrics
+          volumeMounts:
+          resources:
+            limits: {}
+            requests: {}
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/manifests/postgres-with-backup/kustomization.yaml
+++ b/manifests/postgres-with-backup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base/upstream
+  - ../base/backup

--- a/manifests/postgres/kustomization.yaml
+++ b/manifests/postgres/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base/upstream


### PR DESCRIPTION
This is a working version of a shared manifest that can be used across the energy namespace. The Postgres section is working as expected but the backup still needs an upstream review to be merged and some further testing/ux changes.