### PR TITLE
remove Helm labels

### DIFF
--- a/manifests/base/upstream/kustomization.yaml
+++ b/manifests/base/upstream/kustomization.yaml
@@ -4,19 +4,22 @@ resources:
   - postgres.yaml
 patches:
   # Remove unnecessary `app.kubernetes.io/managed-by: Helm` annotation
+  # The JSON Pointer RFC (which is the syntax used to specify the path component of a patch)
+  # / characters needs to be escaped using ~1 according to syntax used to specify path
+  # https://www.rfc-editor.org/rfc/rfc6901 (JSON Pointer RFC)
   - patch: |-
       - op: remove
         path: /metadata/labels/app.kubernetes.io~1managed-by
+      - op: remove
+        path: /metadata/labels/helm.sh~1chart
     target:
-      group: apps
-      version: v1
-      kind: Service
+      kind: Service|StatefulSet
   - patch: |-
       - op: remove
         path: /spec/template/metadata/labels/app.kubernetes.io~1managed-by
+      - op: remove
+        path: /spec/template/metadata/labels/helm.sh~1chart
     target:
-      group: apps
-      version: v1
       kind: StatefulSet
   # remove these empty affinity nodes, as in Kustomize 5.0.x kustomize generates them as strings with value "null" instead of just null, and they can not be applied.
   # added this issue in kustomize: https://github.com/kubernetes-sigs/kustomize/issues/5171
@@ -26,8 +29,6 @@ patches:
       - op: remove
         path: /spec/template/spec/affinity/nodeAffinity
     target:
-      group: apps
-      version: v1
       kind: StatefulSet
   # replace commands with hardcoded values with more flexible commands
   - patch: |-
@@ -40,8 +41,6 @@ patches:
             exec pg_isready -U "$(POSTGRES_USER)" -d "dbname=$(POSTGRES_DATABASE)" -h 127.0.0.1 -p 5432
             [-f /opt/bitnami/postgresql/tmp/.initialized] || [-f /bitnami/postgresql/.initialized]
     target:
-      group: apps
-      version: v1
       kind: StatefulSet
   - patch: |-
       - op: replace
@@ -53,6 +52,4 @@ patches:
             exec pg_isready -U "$(POSTGRES_USER)" -d "dbname=$(POSTGRES_DATABASE)" -h 127.0.0.1 -p 5432
             [-f /opt/bitnami/postgresql/tmp/.initialized] || [-f /bitnami/postgresql/.initialized]
     target:
-      group: apps
-      version: v1
       kind: StatefulSet


### PR DESCRIPTION
Since resources in the manifest are not managed by Helm it is misleading to label them as such