### PR TITLE
fix: add url secret as used by most services

### DIFF
--- a/examples/with-backup/secrets/postgres.properties
+++ b/examples/with-backup/secrets/postgres.properties
@@ -1,2 +1,4 @@
 password=adminpassword
 user-password=userpassword
+url=postgresql://$YOUR_USER:$YOUR_PASSWORD@$KUBE_SERVICE_REFERENCE/$DB_NAME?sslmode=disable
+# make sure to replace everything above with what is appropriate for your postgres deployment!


### PR DESCRIPTION
This is usually expected by the microservices we create