### PR TITLE
Bitname image moved to bitnamilegacy

### DIFF
--- a/manifests/base/postgres/postgres.yaml
+++ b/manifests/base/postgres/postgres.yaml
@@ -82,7 +82,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnami/postgresql:16.3.0-debian-12-r14
+          image: docker.io/bitnamilegacy/postgresql:16.3.0-debian-12-r14
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -193,7 +193,7 @@ spec:
             - name: data
               mountPath: /bitnami/postgresql
         - name: metrics
-          image: docker.io/bitnami/postgres-exporter:0.15.0-debian-12-r33
+          image: docker.io/bitnamilegacy/postgres-exporter:0.15.0-debian-12-r33
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Image is the same, so this is a no-op change

Context: https://github.com/utilitywarehouse/documentation/blob/master/infra/announce/2025-07-22-bitnami-images-eosl.md